### PR TITLE
Skip first row (column headers) when loading data in Matlab with cvsread!

### DIFF
--- a/example.m
+++ b/example.m
@@ -5,8 +5,8 @@
 
 % load dataset
 dataset = '1';
-calcium_train = csvread([dataset '.train.calcium.csv']);
-spike_train = csvread([dataset '.train.spikes.csv']);
+calcium_train = csvread([dataset '.train.calcium.csv'],1,0); % skip first row (column headers)
+spike_train = csvread([dataset '.train.spikes.csv'],1,0);    % skip first row (column headers)
 
 % plot example neuron
 figure


### PR DESCRIPTION
It is only after i almost finished with optimizing my method for the training dataset that i realize that the calcium and real spike value at time zero were erroneous because the first (header) row in the data file was treated as data.